### PR TITLE
Add first-episode OP/ED skip exemption and preserve credits when next-episode skip is disabled

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -2,8 +2,9 @@ const INTRO_UIA = "player-skip-intro";
 const RECAP_UIA = "player-skip-recap";
 const NEXT_UIA = "next-episode-seamless-button";
 const NEXT_DRAIN_UIA = "next-episode-seamless-button-draining";
+const CREDITS_UIA = "watch-credits-seamless-button";
 
-const BUTTONS = [INTRO_UIA, RECAP_UIA, NEXT_UIA, NEXT_DRAIN_UIA];
+const BUTTONS = [INTRO_UIA, RECAP_UIA, NEXT_UIA, NEXT_DRAIN_UIA, CREDITS_UIA];
 
 // Function to extract the current Netflix title
 function getCurrentTitle() {
@@ -32,36 +33,67 @@ function getCurrentTitle() {
   return null;
 }
 
+// Function that checks if the episode is first
+async function isCurrentFirstEpisode() {
+  //If chrome.storage.local has isFirstEpisode, return it to avoid unnecessary DOM queries
+  //Else, check the DOM and set the value in storage for future reference
+  let isFirstEpisode = false;
+  const result = await new Promise((resolve) => {
+    chrome.storage.local.get(["isFirstEpisode"], resolve);
+  });
+
+  if (result.isFirstEpisode !== undefined) {
+    isFirstEpisode = result.isFirstEpisode;
+  }
+
+  const titleElement = document.querySelectorAll("[data-uia='video-title']")[0];
+
+  if (titleElement) {
+    // Try to get the episode number from the span element within the title element
+    const spanElement = titleElement.querySelector("span");
+    // If it's first episode, the element will be like E1.
+    isFirstEpisode = !!(spanElement && spanElement.textContent.trim().startsWith("E1"));
+    chrome.storage.local.set({ isFirstEpisode });
+  }
+  return isFirstEpisode;
+}
+
 async function skipper() {
   try {
-    chrome.storage.local.get(
-      ["skipIntro", "skipRecap", "skipNext", "exemptTitles"],
-      ({ skipIntro, skipRecap, skipNext, exemptTitles = [] }) => {
-        // Check if current title is in exempt list
-        const currentTitle = getCurrentTitle();
-        const isExempt = currentTitle && exemptTitles.includes(currentTitle);
-        
-        // If title is exempt, don't skip anything
-        if (isExempt) {
-          return;
-        }
-        
-        const mapper = {
-          [INTRO_UIA]: skipIntro,
-          [RECAP_UIA]: skipRecap,
-          [NEXT_UIA]: skipNext,
-          [NEXT_DRAIN_UIA]: skipNext,
-        };
-        BUTTONS.forEach((uia) => {
-          const button = Object.values(
-            document.getElementsByTagName("button")
-          ).find((elem) => elem.getAttribute("data-uia") === uia);
-          if (button && mapper[uia]) {
-            button.click();
-          }
-        });
+    const { skipIntro, skipRecap, skipNext, noSkipFirst, exemptTitles = [] } =
+      await new Promise((resolve) => {
+        chrome.storage.local.get(
+          ["skipIntro", "skipRecap", "skipNext", "noSkipFirst", "exemptTitles"],
+          resolve
+        );
+      });
+
+    // Check if current title is in exempt list
+    const currentTitle = getCurrentTitle();
+    const isExempt = currentTitle && exemptTitles.includes(currentTitle);
+
+    // If title is exempt, don't skip anything
+    if (isExempt) {
+      return;
+    }
+
+    const isFirstEpisode = noSkipFirst ? await isCurrentFirstEpisode() : false;
+
+    const mapper = {
+      [INTRO_UIA]: skipIntro && !isFirstEpisode,
+      [RECAP_UIA]: skipRecap,
+      [NEXT_UIA]: skipNext && !isFirstEpisode,
+      [NEXT_DRAIN_UIA]: skipNext && !isFirstEpisode,
+      [CREDITS_UIA]: !skipNext || isFirstEpisode,
+    };
+    BUTTONS.forEach((uia) => {
+      const button = Object.values(
+        document.getElementsByTagName("button")
+      ).find((elem) => elem.getAttribute("data-uia") === uia);
+      if (button && mapper[uia]) {
+        button.click();
       }
-    );
+    });
   } catch (err) {
     console.error(err);
   }

--- a/src/popup.html
+++ b/src/popup.html
@@ -119,6 +119,10 @@
         <input type="checkbox" id="skip-next" name="skip-next">
         <label for="skip-next">Skip Next Episode</label>
       </div>
+      <div class="checkbox-item">
+        <input type="checkbox" id="no-skip-first" name="no-skip-first">
+        <label for="no-skip-first">No OP/ED skip for First Episode</label>
+      </div>
     </div>
     <div class="current-title">
       Playing: <span id="current-title">Loading...</span>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,6 +1,7 @@
 let skipIntroCheckbox = document.getElementById("skip-intro");
 let skipRecapCheckbox = document.getElementById("skip-recap");
 let skipNextCheckbox = document.getElementById("skip-next");
+let noSkipFirstCheckbox = document.getElementById("no-skip-first");
 let toggleExemptButton = document.getElementById("toggle-exempt");
 let currentTitleSpan = document.getElementById("current-title");
 let currentTitleContainer = document.getElementById("current-title-container");
@@ -21,6 +22,10 @@ skipRecapCheckbox.addEventListener("click", async () => {
 
 skipNextCheckbox.addEventListener("click", async () => {
   chrome.storage.local.set({ skipNext: skipNextCheckbox.checked });
+});
+
+noSkipFirstCheckbox.addEventListener("click", async () => {
+  chrome.storage.local.set({ noSkipFirst: noSkipFirstCheckbox.checked });
 });
 
 // Exempt list functionality
@@ -187,8 +192,8 @@ async function getCurrentTitle() {
 async function initializePopup() {
   // Load general settings
   chrome.storage.local.get(
-    ["skipIntro", "skipRecap", "skipNext"],
-    ({ skipIntro, skipRecap, skipNext }) => {
+    ["skipIntro", "skipRecap", "skipNext", "noSkipFirst"],
+    ({ skipIntro, skipRecap, skipNext, noSkipFirst }) => {
       if (skipIntro) {
         skipIntroCheckbox.checked = true;
       }
@@ -197,6 +202,9 @@ async function initializePopup() {
       }
       if (skipNext) {
         skipNextCheckbox.checked = true;
+      }
+      if (noSkipFirst) {
+        noSkipFirstCheckbox.checked = true;
       }
     }
   );


### PR DESCRIPTION
## Summary

This PR adds two improvements to the Netflix viewing flow:

- Add a new **No OP/ED skip for First Episode** setting to avoid skipping OP/ED on episode 1.
- When **Skip Next Episode** is disabled, automatically select **Watch Credits** so the ending continues playing instead of entering the next-episode flow.

## Motivation

These changes are mainly aimed at anime viewers, who often prefer to:
- watch the OP/ED on the first episode
- watch the full ending credits without interruption

## Testing

Tested manually on a few Netflix titles.
Verified:
- first-episode OP/ED skipping stays disabled when the new option is enabled
- credits continue playing when **Skip Next Episode** is disabled

This was only a small manual validation pass, not a full compatibility sweep across all title types.